### PR TITLE
Refactor drift corr

### DIFF
--- a/09_diff_run_preprocess.sh
+++ b/09_diff_run_preprocess.sh
@@ -75,6 +75,14 @@ ${FSL_LOCAL}/fslmaths ${DIFF_DATA_DIR}/data_debias_denoise_degibbs.nii.gz \
 # Detrending the tissue heating effect of increased diffusivity
 echo 'Signal Detrending'
 
+# Concatenate path of all method file in order 
+METHODPATH=''
+for SCANNUM in ${DIFF_SCANS[@]}; do
+  METHODPATH+=${BRUKER_RAW_DIR}'/'$SCANNUM'/method '
+done
+
+python3 ${SCRIPTS}/get_timestamp.py $METHODPATH ${DIFF_DATA_DIR}'/data_timestamps.txt'
+
 python3 ${SCRIPTS}/drift_corr_data.py \
     --in ${DIFF_DATA_DIR}/data_debias_denoise_degibbs.nii.gz \
     --mask ${DIFF_DATA_DIR}/mask.nii.gz \

--- a/09_diff_run_preprocess.sh
+++ b/09_diff_run_preprocess.sh
@@ -87,6 +87,7 @@ python3 ${SCRIPTS}/drift_corr_data.py \
     --in ${DIFF_DATA_DIR}/data_debias_denoise_degibbs.nii.gz \
     --mask ${DIFF_DATA_DIR}/mask.nii.gz \
     --bval ${DIFF_DATA_DIR}/data.bval \
+    --time ${DIFF_DATA_DIR}/data_timestamps.txt \
     --out ${DIFF_DATA_DIR}/data_debias_denoise_degibbs_driftcorr.nii.gz \
 
 

--- a/09_diff_run_preprocess.sh
+++ b/09_diff_run_preprocess.sh
@@ -78,7 +78,7 @@ echo 'Signal Detrending'
 # Concatenate path of all method file in order 
 METHODPATH=''
 for SCANNUM in ${DIFF_SCANS[@]}; do
-  METHODPATH+=${BRUKER_RAW_DIR}'/'$SCANNUM'/method '
+  METHODPATH+=${BRUKER_RAW_DIR}$SCANNUM'/method '
 done
 
 python3 ${SCRIPTS}get_scans_timestamp.py $METHODPATH ${DIFF_DATA_DIR}'/data_timestamps.txt'

--- a/09_diff_run_preprocess.sh
+++ b/09_diff_run_preprocess.sh
@@ -81,7 +81,7 @@ for SCANNUM in ${DIFF_SCANS[@]}; do
   METHODPATH+=${BRUKER_RAW_DIR}'/'$SCANNUM'/method '
 done
 
-python3 ${SCRIPTS}/get_timestamp.py $METHODPATH ${DIFF_DATA_DIR}'/data_timestamps.txt'
+python3 ${SCRIPTS}get_scans_timestamp.py $METHODPATH ${DIFF_DATA_DIR}'/data_timestamps.txt'
 
 python3 ${SCRIPTS}/drift_corr_data.py \
     --in ${DIFF_DATA_DIR}/data_debias_denoise_degibbs.nii.gz \

--- a/scripts/drift_corr_data.py
+++ b/scripts/drift_corr_data.py
@@ -68,13 +68,15 @@ def main():
 
     bvals = np.round(np.genfromtxt(PATH_BVAL), -3).squeeze()
 
-    timestamps = np.genfromtxt(PATH_TIME, fmt='%d')
+    timestamps = np.genfromtxt(PATH_TIME, dtype=np.int)
 
 
     print('Running Drift Correction')
 
     b0_mask = bvals == 0
     b0_idx = np.where(bvals == 0)[0]
+
+    # print('b0 index: {}'.format(b0_idx))
 
     # timestamps of b0s
     x_ = timestamps[b0_idx]
@@ -89,6 +91,19 @@ def main():
     # correction = (m*x_prime + c) / (m*0 + c) = (m*x_prime / c) + 1
     drift_scaling = ((timestamps*m_) / c_) + 1
     data_drift_corr = data[..., :] / drift_scaling
+
+    # import pylab as pl 
+    # pl.figure()
+    # pl.subplot(1,2,1)
+    # pl.plot(timestamps, m_*timestamps + c_)
+    # pl.scatter(x_, data_mean[b0_idx])
+    # pl.title('Fit on B0s')
+    # pl.subplot(1,2,2)
+    # pl.semilogy(timestamps, data_mean, label='before', alpha=0.5)
+    # pl.semilogy(timestamps, data_drift_corr[mask].mean(axis=0), label='after', alpha=0.5)
+    # pl.legend()
+    # pl.title('Drift correction on data')
+    # pl.show()
 
 
     # Save Data

--- a/scripts/drift_corr_data.py
+++ b/scripts/drift_corr_data.py
@@ -66,7 +66,7 @@ def main():
 
     mask = nib.load(PATH_MASK).get_fdata().astype(np.bool)
 
-    bvals = np.round(np.genfromtxt(PATH_BVAL), -3).squeeze()
+    bvals = np.genfromtxt(PATH_BVAL)
 
     timestamps = np.genfromtxt(PATH_TIME, dtype=np.int)
 
@@ -74,7 +74,7 @@ def main():
     print('Running Drift Correction')
 
     b0_mask = bvals == 0
-    b0_idx = np.where(bvals == 0)[0]
+    b0_idx = np.where(bvals < 0.01)[0]
 
     # print('b0 index: {}'.format(b0_idx))
 

--- a/scripts/get_scans_timestamp.py
+++ b/scripts/get_scans_timestamp.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from datetime import datetime, timedelta
+import argparse
+
+
+
+DESCRIPTION = """
+Compute an accurate timestamps for each volume based on method files.
+"""
+
+EPILOG = """
+Michael Paquette, MPI CBS, 2021.
+"""
+
+class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    pass
+
+def buildArgsParser():
+
+    p = argparse.ArgumentParser(description=DESCRIPTION,
+                                epilog=EPILOG,
+                                formatter_class=CustomFormatter)
+
+    p.add_argument('method', type=str, nargs='+', default=[],
+                   help='Path of the input method file(s) (one or more).')
+    p.add_argument('output', type=str,
+                   help='Path of the output.')
+    return p
+
+
+# read all lines and parse into list
+def rawtext(fname):
+    with open(fname, 'r') as f:
+        return f.readlines()
+
+
+# find a tag and grap everything until the next '$$' or '##'
+def grab_tag(rawmethod, tag):
+    # remove tag marker if there
+    if tag[:3] == '##$':
+        tag = tag[3:]
+    # loop list until found
+    tagindex = None
+    for i,l in enumerate(rawmethod):
+        if l[:len(tag)+3] == '##$' + tag:
+            tagindex = i
+            break
+    if i is None:
+        print('tag not found')
+        return None
+    # find the end of tag
+    end_tag = None
+    j = 1
+    while end_tag is None:
+        tmp = rawmethod[i+j][:2]
+        if (tmp == '$$') or (tmp == '##'):
+            end_tag = i+j
+        j += 1
+    
+    return rawmethod[i:end_tag]
+
+
+# parse single line float tag
+def parse_tag_single_line_float(rawtag):
+    return np.array([float(rawtag[0].strip().split('=')[-1])])
+
+
+# parse multiline float tag
+def parse_tag_multi_line_float(rawtag):
+    arrayshape = tuple([int(n) for n in rawtag[0].strip().split('=')[-1][1:-1].split(',')])
+    array1D = np.concatenate([np.array([float(n) for n in l.strip().split(' ')]) for l in rawtag[1:]])
+    return array1D.reshape(arrayshape)
+
+
+# parse multiline string tag
+def parse_tag_multi_line_string(rawtag):
+    return rawtag[1].strip()[1:-1]
+
+
+# parse any tag using heuristic to decide between:
+#     parse_tag_single_line_float
+#     parse_tag_multi_line_float
+#     parse_tag_multi_line_string
+def parse_tag(rawtag):
+    if len(rawtag) == 1:
+        return parse_tag_single_line_float(rawtag)
+    elif rawtag[1][0] == '<':
+        return parse_tag_multi_line_string(rawtag)
+    else:
+        return parse_tag_multi_line_float(rawtag)
+
+
+# convert the dates, durations and number of sub partitions 
+# into time in seconds from start of experiment
+# for linear (in time) fit
+def timestamp_to_seconds(end_timestamp, durations, n_partitions):
+    # end_timestamp is a list of datetime object with the end of the events
+    # durations is a list timedelta object with the length of each event
+    # n_partitions is a list with the number of even-lenght sub-events in each event
+    time_zero = min([end_timestamp[i]-durations[i] for i in range(len(end_timestamp))])
+    subevent_timestamp = []
+    for i in range(len(end_timestamp)):
+        sub_event_duration = durations[i] / n_partitions[i]
+        tmp = [end_timestamp[i] - (j+0.5)*sub_event_duration for j in range(n_partitions[i]-1, -1, -1)]
+        subevent_timestamp.append([(t-time_zero).total_seconds() for t in tmp])
+    return subevent_timestamp
+
+
+def main():
+    parser = buildArgsParser()
+    args = parser.parse_args()
+
+
+    end_timestamp = []
+    durations = []
+    n_partitions = []
+
+    for fname in args.method:
+        print(fname)
+        rawmethod = rawtext(fname)
+
+        # locate ##OWNER tag to find end of scan timestamp
+        end_timestamp_line_index = np.argwhere([l[:7]=='##OWNER' for l in rawmethod])[0][0] + 1
+        date_time_str = ' '.join(rawmethod[end_timestamp_line_index].split(' ')[1:3]) # strip non date part
+        date_time_obj = datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S.%f') # parse date with 4 digit year and miliseconds
+        # print(date_time_obj)
+        end_timestamp.append(date_time_obj)
+
+
+
+        # locate PVM_ScanTimeStr for scan duration
+        delta_time_str = parse_tag(grab_tag(rawmethod, 'PVM_ScanTimeStr'))
+        # parse into deltatime
+        tmp_boundary = [s.isdigit() for s in delta_time_str]
+        breaks = [0]
+        for i in range(len(tmp_boundary)-1):
+            if not tmp_boundary[i] and tmp_boundary[i+1]: # looking for False-True
+                breaks.append(i+1)
+        breaks.append(None)
+
+        # since the PVM_ScanTimeStr doesnt always have the same element
+        # we parse and use **kwargs to create timedelta object
+        timetag = {'d': 'days', 'h': 'hours', 'm': 'minutes', 's': 'seconds', 'ms': 'microseconds'}
+        duration = {}
+        for i in range(len(breaks)-1):
+            # print(delta_time_str[breaks[i]:breaks[i+1]])
+
+            el_list = delta_time_str[breaks[i]:breaks[i+1]]
+            type_list = tmp_boundary[breaks[i]:breaks[i+1]]
+
+            tmp1 = int(''.join([el_list[j] for j in range(len(el_list)) if type_list[j]]))
+            tmp2 = ''.join([el_list[j] for j in range(len(el_list)) if not type_list[j]])
+
+            duration[timetag[tmp2]] = tmp1
+
+        delta_time_obj = timedelta(**duration)
+        # print(delta_time_obj)
+        durations.append(delta_time_obj)
+
+
+
+        # not required if we only use budde sequence
+        # but this could be use to return a 1 for non existing field
+        # def get_val(rawmethod, tag):
+        #   try:
+        #       rawtag = grab_tag(rawmethod, tag)
+        #       val = parse_tag(rawtag)
+        #   except IndexError:
+        #       val = np.array([1])
+        #   return val
+
+
+        # to estimate de total number of volume,
+        # we multiply echos, repetitions, bvalue, bshape and bvecs
+        # we can ignore average since they are internally averaged
+        NEcho = parse_tag(grab_tag(rawmethod, 'PVM_NEchoImages'))[0]
+        NRep = parse_tag(grab_tag(rawmethod, 'PVM_NRepetitions'))[0]
+        Nbvec = parse_tag(grab_tag(rawmethod, 'DwNDirs'))[0]
+        Nbval = parse_tag(grab_tag(rawmethod, 'DwNAmplitudes'))[0]
+        # this is most likely wrong, I don't know how multiple waveform shape are stored in the method
+        Nbshape = len(parse_tag(grab_tag(rawmethod, 'DwDynGradShapeEnum1')).split(' '))
+
+        Nvol = int(NEcho * NRep * Nbvec * Nbval * Nbshape)  
+        # print(Nvol)
+        n_partitions.append(Nvol)
+
+
+    # this is a list of list for all individual event
+    time_for_drift_corr = timestamp_to_seconds(end_timestamp, durations, n_partitions)
+    # we flatten the list
+    time_for_drift_corr = np.array([item for sublist in time_for_drift_corr for item in sublist])
+
+
+    np.savetxt(args.output, time_for_drift_corr, fmt='%d')
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/get_scans_timestamp.py
+++ b/scripts/get_scans_timestamp.py
@@ -127,23 +127,24 @@ def main():
     n_partitions = []
 
     for fname in args.method:
+        print(' ')
         print(fname)
         rawmethod = rawtext(fname)
 
         # detect method name
         # only support <Bruker:DtiEpi> and <User:mcw_DWEpiWavev7>
         method_name = parse_tag(grab_tag(rawmethod, 'Method'))
-        # print('Types of method: {}'.format(method_name))
+        print('Type of method: {}'.format(method_name))
 
         if (method_name == 'Bruker:DtiEpi') or (method_name == 'User:mcw_DWEpiWavev7'):
             # locate ##OWNER tag to find end of scan timestamp
             end_timestamp_line_index = np.argwhere([l[:7]=='##OWNER' for l in rawmethod])[0][0] + 1
             date_time_str = ' '.join(rawmethod[end_timestamp_line_index].split(' ')[1:3]) # strip non date part
             date_time_obj = datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S.%f') # parse date with 4 digit year and miliseconds
-            # print(date_time_obj)
             end_timestamp.append(date_time_obj)
         else:
             return None
+        print('End of scan ', date_time_obj)
 
 
 
@@ -174,10 +175,10 @@ def main():
                 duration[timetag[tmp2]] = tmp1
 
             delta_time_obj = timedelta(**duration)
-            # print(delta_time_obj)
             durations.append(delta_time_obj)
         else:
             return None
+        print('scan duration ', delta_time_obj)
 
 
 
@@ -196,24 +197,35 @@ def main():
             # to estimate de total number of volume,
             # we multiply echos, repetitions, bvalue, bshape and bvecs
             # we can ignore average since they are internally averaged
-            NEcho = parse_tag(grab_tag(rawmethod, 'PVM_NEchoImages'))[0]
-            NRep = parse_tag(grab_tag(rawmethod, 'PVM_NRepetitions'))[0]
-            Nbvec = parse_tag(grab_tag(rawmethod, 'DwNDirs'))[0]
-            Nbval = parse_tag(grab_tag(rawmethod, 'DwNAmplitudes'))[0]
+            NEcho = int(parse_tag(grab_tag(rawmethod, 'PVM_NEchoImages'))[0])
+            NRep = int(parse_tag(grab_tag(rawmethod, 'PVM_NRepetitions'))[0])
+            Nbvec = int(parse_tag(grab_tag(rawmethod, 'DwNDirs'))[0])
+            Nbval = int(parse_tag(grab_tag(rawmethod, 'DwNAmplitudes'))[0])
             # this is most likely wrong, I don't know how multiple waveform shape are stored in the method
             Nbshape = len(parse_tag(grab_tag(rawmethod, 'DwDynGradShapeEnum1')).split(' '))
 
-            Nvol = int(NEcho * NRep * Nbvec * Nbval * Nbshape)
+            Nvol = NEcho * NRep * Nbvec * Nbval * Nbshape
+
+            print('{} echos'.format(NEcho))
+            print('{} Repetitions'.format(NRep))
+            print('{} bvecs'.format(Nbvec))
+            print('{} bvals'.format(Nbval))
+            print('{} btensor shapes'.format(Nbshape))
+            print('{} Total volumes'.format(Nvol))
 
         elif (method_name == 'Bruker:DtiEpi'):
-            NEcho = parse_tag(grab_tag(rawmethod, 'PVM_NEchoImages'))[0]
-            NRep = parse_tag(grab_tag(rawmethod, 'PVM_NRepetitions'))[0]
-            NDwi = parse_tag(grab_tag(rawmethod, 'PVM_DwNDiffDir'))[0]
+            NEcho = int(parse_tag(grab_tag(rawmethod, 'PVM_NEchoImages'))[0])
+            NRep = int(parse_tag(grab_tag(rawmethod, 'PVM_NRepetitions'))[0])
+            NDwi = int(parse_tag(grab_tag(rawmethod, 'PVM_DwNDiffDir'))[0])
 
-            Nvol = int(NEcho * NRep * NDwi)
+            Nvol = NEcho * NRep * NDwi
+
+            print('{} echos'.format(NEcho))
+            print('{} Repetitions'.format(NRep))
+            print('{} DWIs'.format(NDwi))
+            print('{} Total volumes'.format(Nvol))
 
 
-        # print(Nvol)
         n_partitions.append(Nvol)
 
 

--- a/scripts/get_scans_timestamp.py
+++ b/scripts/get_scans_timestamp.py
@@ -152,7 +152,7 @@ def main():
             # locate PVM_ScanTimeStr for scan duration
             delta_time_str = parse_tag(grab_tag(rawmethod, 'PVM_ScanTimeStr'))
             # parse into deltatime
-            tmp_boundary = [s.isdigit() for s in delta_time_str]
+            tmp_boundary = [s.isdigit()|(s=='.') for s in delta_time_str]
             breaks = [0]
             for i in range(len(tmp_boundary)-1):
                 if not tmp_boundary[i] and tmp_boundary[i+1]: # looking for False-True
@@ -161,7 +161,7 @@ def main():
 
             # since the PVM_ScanTimeStr doesnt always have the same element
             # we parse and use **kwargs to create timedelta object
-            timetag = {'d': 'days', 'h': 'hours', 'm': 'minutes', 's': 'seconds', 'ms': 'microseconds'}
+            timetag = {'d': 'days', 'h': 'hours', 'm': 'minutes', 's': 'seconds', 'ms': 'milliseconds'}
             duration = {}
             for i in range(len(breaks)-1):
                 # print(delta_time_str[breaks[i]:breaks[i+1]])
@@ -169,7 +169,7 @@ def main():
                 el_list = delta_time_str[breaks[i]:breaks[i+1]]
                 type_list = tmp_boundary[breaks[i]:breaks[i+1]]
 
-                tmp1 = int(''.join([el_list[j] for j in range(len(el_list)) if type_list[j]]))
+                tmp1 = float(''.join([el_list[j] for j in range(len(el_list)) if type_list[j]]))
                 tmp2 = ''.join([el_list[j] for j in range(len(el_list)) if not type_list[j]])
 
                 duration[timetag[tmp2]] = tmp1


### PR DESCRIPTION
Adds a function reading scans data, duration and number of volumes from method files to generate relative realtime vector of scans. 
Modified the drift correction to use that vector in the linear fit and in the correction factor.
Works for both "Bremerhaven" (<Bruker:DtiEpi>) and "Magdeburg" (<User:mcw_DWEpiWavev7>)